### PR TITLE
Use bitcoin-cli instead of bitcoind

### DIFF
--- a/bin/lamassu-bitcoind-install
+++ b/bin/lamassu-bitcoind-install
@@ -95,7 +95,7 @@ EOF
 start bitcoind
 
 echo "Waiting for bitcoind to load."
-until bitcoind getblockcount &>/dev/null; do sleep 1; done
+until bitcoin-cli getblockcount &>/dev/null; do sleep 1; done
 
 # Set up wallet backup cron job
 echo -e "MAILTO=$EMAIL_ADDRESS\n00 05 * * * /usr/local/bin/lamassu-bitcoind-backup \"$EMAIL_ADDRESS\"" | \


### PR DESCRIPTION
When running `lamassu-bitcoind-install <email address>` the installer would stop at `Waiting for bitcoind to load.`

`Error: There is no RPC client functionality in bitcoind anymore. Use the bitcoin-cli utility instead.`