### PR TITLE
Adds back bins, lamassu-bills-log, bumps 0.2.12

### DIFF
--- a/bin/lamassu-bills-log
+++ b/bin/lamassu-bills-log
@@ -18,11 +18,11 @@ then
   DEBIAN_FRONTEND=noninteractive apt-get install -y mutt >/dev/null;
 fi
 
-BILLS_FILE=/tmp/bills-$(date -u "+%Y-%m-%d_%H-%M-%S").csv
+BILLS_FILE=/tmp/bills-$HOSTNAME-$(date -u "+%Y-%m-%d_%H-%M-%S").csv
 su - postgres -c "psql \"lamassu\" -Atc \"COPY bills to '$BILLS_FILE' WITH CSV HEADER\""
 gpg --batch --trust-model always -e -r $EMAIL_ADDRESS $BILLS_FILE
 rm $BILLS_FILE
 export EMAIL="Bills Log <$EMAIL_ADDRESS>"
-echo "Attached is your encrypted bills log." | mutt -s "Encrypted machine bills" -a $BILLS_FILE.gpg -- $EMAIL_ADDRESS
+echo "Attached is your encrypted bills log." | mutt -s "Encrypted machine bills from $HOSTNAME" -a $BILLS_FILE.gpg -- $EMAIL_ADDRESS
 rm $BILLS_FILE.gpg
 echo "Bills log sent to $EMAIL_ADDRESS. If it doesn't appear, check your spam folder."

--- a/bin/lamassu-bills-log
+++ b/bin/lamassu-bills-log
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+EMAIL_ADDRESS=$1
+if [ ! $# -eq 1 ]; then
+  echo "lamassu-bills-log <email_address>"
+  exit 1
+elif [[ ! $EMAIL_ADDRESS =~ .+@.+\..+ ]]; then
+  echo "Please enter a valid email address."
+  echo
+  echo "lamassu-bills-log <email_address>"
+  exit 1
+fi
+
+if [ $(dpkg-query -W -f='${Status}' mutt 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+  echo "Mutt not installed. Installing..."
+  DEBIAN_FRONTEND=noninteractive apt-get install -y mutt >/dev/null;
+fi
+
+BILLS_FILE=/tmp/bills-$(date -u "+%Y-%m-%d_%H-%M-%S").csv
+su - postgres -c "psql \"lamassu\" -Atc \"COPY bills to '$BILLS_FILE' WITH CSV HEADER\""
+gpg --batch --trust-model always -e -r $EMAIL_ADDRESS $BILLS_FILE
+rm $BILLS_FILE
+export EMAIL="Bills Log <$EMAIL_ADDRESS>"
+echo "Attached is your encrypted bills log." | mutt -s "Encrypted machine bills" -a $BILLS_FILE.gpg -- $EMAIL_ADDRESS
+rm $BILLS_FILE.gpg
+echo "Bills log sent to $EMAIL_ADDRESS. If it doesn't appear, check your spam folder."

--- a/bin/lamassu-bitcoind-backup
+++ b/bin/lamassu-bitcoind-backup
@@ -14,7 +14,7 @@ fi
 
 mkdir -p $HOME/archive
 BACKUP_FILE=$HOME/archive/wallet-$(date -u "+%Y-%m-%d_%H-%M-%S").bak
-bitcoind backupwallet $BACKUP_FILE
+bitcoin-cli backupwallet $BACKUP_FILE
 gpg --batch --trust-model always -e -r $EMAIL_ADDRESS $BACKUP_FILE
 rm $BACKUP_FILE
 export EMAIL="Bitcoin Backup <$EMAIL_ADDRESS>"

--- a/bin/lamassu-bitcoind-install
+++ b/bin/lamassu-bitcoind-install
@@ -95,7 +95,7 @@ EOF
 start bitcoind
 
 echo "Waiting for bitcoind to load."
-until bitcoind getblockcount &>/dev/null; do sleep 1; done
+until bitcoin-cli getblockcount &>/dev/null; do sleep 1; done
 
 # Set up wallet backup cron job
 echo -e "MAILTO=$EMAIL_ADDRESS\n00 05 * * * /usr/local/bin/lamassu-bitcoind-backup \"$EMAIL_ADDRESS\"" | \
@@ -113,4 +113,3 @@ echo
 echo "When your blockchain has caught up, run lamassu-bitcoind-enable to start"
 echo "using bitcoind as your remote server wallet."
 echo
-

--- a/bin/lamassu-transactions-csv
+++ b/bin/lamassu-transactions-csv
@@ -18,11 +18,11 @@ then
   DEBIAN_FRONTEND=noninteractive apt-get install -y mutt >/dev/null;
 fi
 
-TRANSACTIONS_FILE=/tmp/transactions-$(date -u "+%Y-%m-%d_%H-%M-%S").csv
+TRANSACTIONS_FILE=/tmp/transactions-$HOSTNAME-$(date -u "+%Y-%m-%d_%H-%M-%S").csv
 su - postgres -c "psql \"lamassu\" -Atc \"COPY transactions to '$TRANSACTIONS_FILE' WITH CSV HEADER\""
 gpg --batch --trust-model always -e -r $EMAIL_ADDRESS $TRANSACTIONS_FILE
 rm $TRANSACTIONS_FILE
 export EMAIL="Transactions Log <$EMAIL_ADDRESS>"
-echo "Attached is your encrypted transactions log." | mutt -s "Encrypted machine transactions" -a $TRANSACTIONS_FILE.gpg -- $EMAIL_ADDRESS
+echo "Attached is your encrypted transactions log." | mutt -s "Encrypted machine transactions from $HOSTNAME" -a $TRANSACTIONS_FILE.gpg -- $EMAIL_ADDRESS
 rm $TRANSACTIONS_FILE.gpg
 echo "Transaction log sent to $EMAIL_ADDRESS. If it doesn't appear, check your spam folder."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-scripts",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "author": "Lamassu (https://lamassu.is)",
   "bin": {
     "lamassu-install": "./bin/lamassu-install",
@@ -18,7 +18,8 @@
     "ssu-name": "./bin/ssu-name",
     "ssu-limits": "./bin/ssu-limits",
     "ssu-bills": "./bin/ssu-bills",
-    "ssu-cartridges": "./bin/ssu-cartridges"
+    "ssu-cartridges": "./bin/ssu-cartridges",
+    "ssu-remit": "./bin/ssu-remit"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "ssu-limits": "./bin/ssu-limits",
     "ssu-bills": "./bin/ssu-bills",
     "ssu-cartridges": "./bin/ssu-cartridges",
-    "ssu-remit": "./bin/ssu-remit"
+    "ssu-remit": "./bin/ssu-remit",
+    "ssu-raqia": "./bin/ssu-raqia"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-scripts",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "author": "Lamassu (https://lamassu.is)",
   "bin": {
     "lamassu-install": "./bin/lamassu-install",
@@ -20,7 +20,8 @@
     "ssu-bills": "./bin/ssu-bills",
     "ssu-cartridges": "./bin/ssu-cartridges",
     "ssu-remit": "./bin/ssu-remit",
-    "ssu-raqia": "./bin/ssu-raqia"
+    "ssu-raqia": "./bin/ssu-raqia",
+    "lamassu-bills-log": "./bin/lamassu-bills-log"
   },
   "dependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
Change log:

- Resolves issue where bins were left out of `package.json` on 0.2.11.
- `lamassu-transacions-csv`: Adds hostname to subject and filenames. Helps differentiate droplets, may help with emails getting bounced by hosts.
- Adds `lamassu-bills-log` (clone of `lamassu-transactions-csv` for the `bills` table.)
- `lamassu-bitcoind-backup`: uses `bitcoin-cli` instead of `bitcoind`
- `lamassu-bitcoind-install`: incorporates #33 