### PR TITLE
transactionFee per byte raised to match current network conditions

### DIFF
--- a/database/lamassu.sql
+++ b/database/lamassu.sql
@@ -81,7 +81,7 @@ COPY user_config (id, type, data) FROM stdin;
       "retryInterval": 5000,\
       "retries": 3,\
       "lowBalanceMargin": 1.05,\
-      "transactionFee": 10000,\
+      "transactionFee": 100000,\
       "tickerDelta": 0,\
       "minimumTradeFiat": 0\
     },\


### PR DESCRIPTION
transactionFee per byte increased to match recent rises in miners fees and block times, which pales in comparison to wallet service fees anyway.  With 10,000 some transactions were taking _days_

Ideally this might be fetched with a script periodically from some of the fees stats websites and increased or decreased gradually.

Having all this config in a JSON object makes such a script harder though, and a slight risk of two things (e.g. a periodic script and admin) overwriting each other's JSON chunks